### PR TITLE
Cleaned setBanqueCentrale and getBanqueCentrale from ServerTCP

### DIFF
--- a/src/main/java/banqueServeur/ServeurTCP.java
+++ b/src/main/java/banqueServeur/ServeurTCP.java
@@ -13,7 +13,7 @@ public class ServeurTCP extends Thread {
 	private static int nbConnexions = 0;
 
 	/** Maximum de connexions client autorisées */
-	private int maxConnexions;
+	private final int maxConnexions;
 
 	private Socket clientSocket;
 
@@ -21,7 +21,7 @@ public class ServeurTCP extends Thread {
 
 	private IProtocole protocole;
 
-	private int numeroPort;
+	private final int numeroPort;
 
 	public ServeurTCP(int unNumeroPort) {
 		numeroPort = unNumeroPort;
@@ -32,14 +32,6 @@ public class ServeurTCP extends Thread {
 		this(port);
 		contexte = b;
 		protocole = p;
-	}
-
-	public void setBanqueCentrale(IContext uneBanque) {
-		contexte = uneBanque;
-	}
-
-	public IContext getBanqueCentrale() {
-		return contexte;
 	}
 
 	@Override


### PR DESCRIPTION
Suppression des méthodes inutiles dans le serverTCP.
Cela a été discuté en cours.